### PR TITLE
Fix status badge helper and cliente list view

### DIFF
--- a/app/Helpers/clientes_helper.php
+++ b/app/Helpers/clientes_helper.php
@@ -1,18 +1,27 @@
 <?php
 
 if (!function_exists('statusCliente')) {
-    function statusCliente(array $cliente): string
+    /**
+     * Retorna um badge de status do cliente considerando o número de dias de inatividade.
+     *
+     * Aceita tanto objetos (Entities) quanto arrays associativos.
+     */
+    function statusCliente($cliente, int $diasInatividade = 60): string
     {
-        if (empty($cliente['data_ultima_compra'])) {
+        $dataUltima = is_object($cliente)
+            ? ($cliente->data_ultima_compra ?? null)
+            : ($cliente['data_ultima_compra'] ?? null);
+
+        if (empty($dataUltima)) {
             return '<span class="badge bg-secondary">Inativo</span>';
         }
 
-        $ultimaCompra = \CodeIgniter\I18n\Time::parse($cliente['data_ultima_compra']);
-        $hoje = \CodeIgniter\I18n\Time::now();
+        $ultimaCompra = \CodeIgniter\I18n\Time::parse($dataUltima);
+        $hoje         = \CodeIgniter\I18n\Time::now();
 
         $diasDesdeUltimaCompra = $hoje->difference($ultimaCompra)->getDays();
 
-        if ($diasDesdeUltimaCompra <= 60) {
+        if ($diasDesdeUltimaCompra <= $diasInatividade) {
             return '<span class="badge bg-success">Ativo</span>';
         }
 

--- a/app/Views/clientes/index.php
+++ b/app/Views/clientes/index.php
@@ -57,10 +57,10 @@ $mostrarColunas = explode(',', $colunasString);
                 <td><?= esc($cliente->cidade) ?></td>
                 <td><?= esc($cliente->nicho) ?></td>
                 <?php if (in_array('data_ultima_compra', $mostrarColunas)): ?>
-                    <td><?= formatar_data_br($cliente['data_ultima_compra']) ?></td>
+                    <td><?= formatar_data_br($cliente->data_ultima_compra) ?></td>
                 <?php endif; ?>
                 <?php if (in_array('total_gasto', $mostrarColunas)): ?>
-                    <td><?= formatar_real($cliente['total_gasto']) ?></td>
+                    <td><?= formatar_real($cliente->total_gasto) ?></td>
                 <?php endif; ?>
                 <?php if (in_array('status', $mostrarColunas)): ?>
                     <td><?= statusCliente($cliente) ?></td>


### PR DESCRIPTION
## Summary
- allow `statusCliente` to accept entity objects
- fix cliente index view to use object properties

## Testing
- `php vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684a2f02c0448321af8e556c6fe57b47