### PR TITLE
Add status field to pedidos

### DIFF
--- a/app/Controllers/Pedidos.php
+++ b/app/Controllers/Pedidos.php
@@ -32,6 +32,7 @@ class Pedidos extends Controller
         $valor     = (float) $this->request->getPost('valor');
         $data      = $this->request->getPost('data');
         $descricao = $this->request->getPost('descricao');
+        $status    = $this->request->getPost('status');
 
         $erros = [];
 
@@ -55,6 +56,7 @@ class Pedidos extends Controller
             'valor'       => $valor,
             'data_compra' => $data,
             'descricao'   => $descricao,
+            'status'      => $status,
         ]);
 
         // Atualiza os dados do cliente usando a Entity
@@ -103,6 +105,7 @@ class Pedidos extends Controller
         $valorNovo   = (float) $this->request->getPost('valor');
         $data        = $this->request->getPost('data');
         $descricao   = $this->request->getPost('descricao');
+        $status      = $this->request->getPost('status');
 
         $erros = [];
 
@@ -121,6 +124,7 @@ class Pedidos extends Controller
             'valor'       => $valorNovo,
             'data_compra' => Time::createFromFormat('Y-m-d H:i:s', $data . ' 00:00:00'),
             'descricao'   => $descricao,
+            'status'      => $status,
         ]);
 
         $clienteModel = new ClienteModel();

--- a/app/Database/Migrations/2025-06-12-000001_add_status_to_pedidos.php
+++ b/app/Database/Migrations/2025-06-12-000001_add_status_to_pedidos.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddStatusToPedidos extends Migration
+{
+    public function up(): void
+    {
+        $this->forge->addColumn('pedidos', [
+            'status' => [
+                'type' => 'TEXT',
+                'null' => true,
+                'after' => 'descricao'
+            ]
+        ]);
+    }
+
+    public function down(): void
+    {
+        $this->forge->dropColumn('pedidos', 'status');
+    }
+}

--- a/app/Models/PedidosModel.php
+++ b/app/Models/PedidosModel.php
@@ -16,6 +16,7 @@ class PedidosModel extends Model
         'data_compra',
         'valor',
         'descricao',
+        'status',
     ];
 
     protected array $casts = [

--- a/app/Views/clientes/historico.php
+++ b/app/Views/clientes/historico.php
@@ -20,6 +20,7 @@
                     <th>Data</th>
                     <th>Valor</th>
                     <th>Descrição</th>
+                    <th>Status</th>
                     <th class="text-center">Ações</th>
                 </tr>
             </thead>
@@ -29,6 +30,7 @@
                         <td><?= formatar_data_br($pedido->data_compra) ?></td>
                         <td><?= formatar_real($pedido->valor) ?></td>
                         <td><?= esc($pedido->descricao) ?></td>
+                        <td><?= esc($pedido->status) ?></td>
                         <td class="text-center">
                             <a class="btn btn-sm btn-outline-secondary" href="<?= base_url('pedidos/editar/' . $pedido->id) ?>">Editar</a>
                             <a class="btn btn-sm btn-outline-danger" href="<?= base_url('pedidos/excluir/' . $pedido->id) ?>" onclick="return confirm('Deseja excluir este pedido?')">Excluir</a>

--- a/app/Views/pedidos/form.php
+++ b/app/Views/pedidos/form.php
@@ -49,6 +49,11 @@
             <textarea name="descricao" id="descricao" class="form-control"><?= esc($pedido->descricao ?? '') ?></textarea>
         </div>
 
+        <div class="mb-3">
+            <label for="status" class="form-label">Status:</label>
+            <input type="text" name="status" id="status" class="form-control" value="<?= esc($pedido->status ?? '') ?>">
+        </div>
+
         <button type="submit" class="btn btn-primary">Salvar</button>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- add database migration to add `status` column in `pedidos`
- include `status` in `PedidosModel` allowed fields
- handle `status` in `Pedidos` controller
- expose `status` field in the pedidos form and historic view

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850b264ab488321bb1ebd01723196b2