### PR TITLE
Improve client list view layout

### DIFF
--- a/app/Views/clientes/index.php
+++ b/app/Views/clientes/index.php
@@ -11,6 +11,15 @@ $mostrarColunas = explode(',', $colunasString);
 
 <a href="<?= base_url('/clientes/criar') ?>" class="btn btn-primary mb-3">➕ Adicionar Cliente</a>
 
+<form method="get" class="row g-2 mb-3">
+    <div class="col-auto">
+        <input type="text" name="q" class="form-control" placeholder="Buscar cliente..." value="<?= esc($buscar) ?>">
+    </div>
+    <div class="col-auto">
+        <button class="btn btn-primary">Buscar</button>
+    </div>
+</form>
+
 <table class="table table-bordered table-striped">
     <thead>
         <tr>
@@ -38,14 +47,6 @@ $mostrarColunas = explode(',', $colunasString);
         </tr>
     </thead>
     <tbody>
-        <form method="get" class="mb-3 row g-2">
-            <div class="col-auto">
-                <input type="text" name="q" class="form-control" placeholder="Buscar cliente..." value="<?= esc($buscar) ?>">
-            </div>
-            <div class="col-auto">
-                <button class="btn btn-primary">Buscar</button>
-            </div>
-        </form>
         <?php foreach ($clientes as $cliente): ?>
             <tr>
                 <td><?= esc($cliente->nome) ?></td>
@@ -74,10 +75,10 @@ $mostrarColunas = explode(',', $colunasString);
                     <a href="<?= base_url("/clientes/{$cliente->id}/painel") ?>" class="btn btn-sm btn-info">Painel</a>
                     <a href="<?= base_url('pedidos/adicionar?cliente_id=' . $cliente->id) ?>" class="btn btn-sm btn-success">Novo Pedido</a>
                 </td>
-                <?= $pager->links('grupoClientes', 'default_full') ?>
             </tr>
         <?php endforeach; ?>
     </tbody>
 </table>
+<?= $pager->links('grupoClientes', 'default_full') ?>
 
 <?php $this->endSection(); ?>


### PR DESCRIPTION
## Summary
- fix HTML layout for client list
- search form moved above table
- move pagination links below table

## Testing
- `php vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_6850c609ac688321a9826ebcb1ddc817